### PR TITLE
Parametrize hosts

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -61,7 +61,7 @@ http {
 
       location {{ WEB_WEBMAIL }} {
         rewrite ^{{ WEB_WEBMAIL }}/(.*) /$1 break;
-        proxy_pass http://webmail;
+        proxy_pass http://{{ HOST_WEBMAIL }};
       }
       {% endif %}
 
@@ -72,14 +72,14 @@ http {
       location ~ {{ WEB_ADMIN }}/(ui|static) {
         rewrite ^{{ WEB_ADMIN }}/(.*) /$1 break;
         proxy_set_header X-Forwarded-Prefix {{ WEB_ADMIN }};
-        proxy_pass http://admin;
+        proxy_pass http://{{ HOST_ADMIN }};
       }
       {% endif %}
 
       {% if WEBDAV != 'none' %}
       location /webdav {
         rewrite ^/webdav/(.*) /$1 break;
-        proxy_pass http://webdav:5232;
+        proxy_pass http://{{ HOST_WEBDAV }}:5232;
       }
       {% endif %}
       {% endif %}
@@ -90,7 +90,7 @@ http {
       listen 127.0.0.1:8000;
 
       location / {
-        proxy_pass http://admin/internal/;
+        proxy_pass http://{{ HOST_ADMIN }}/internal/;
       }
     }
 }

--- a/config.py
+++ b/config.py
@@ -18,6 +18,13 @@ if args["TLS"] and not all(os.path.exists(file_path) for file_path in args["TLS"
     print("Missing cert or key file, disabling TLS")
     args["TLS_ERROR"] = "yes"
 
+if "HOST_WEBMAIL" not in args:
+    args["HOST_WEBMAIL"] = "webmail"
+if "HOST_ADMIN" not in args:
+    args["HOST_ADMIN"] = "admin"
+if "HOST_WEBDAV" not in args:
+    args["HOST_WEBDAV"] = "webdav"
+
 
 convert("/conf/tls.conf", "/etc/nginx/tls.conf", args)
 convert("/conf/nginx.conf", "/etc/nginx/nginx.conf", args)


### PR DESCRIPTION
Allows to use mailu without docker-compose when hostnames are not set up
by docker itself but provided via a separate resolver.

Use case: use mailu using nomad scheduler and consul resolver instead of docker-compose. Other servers are provided by the DNS resolver that resolves names like `admin.service.consul` or `webmail.service.consul`. These names needs to be configurable.